### PR TITLE
Add bash configuration

### DIFF
--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -1,4 +1,47 @@
 ---
+- name: Install git autocomplete.
+  get_url:
+    url: https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
+    dest: "{{ git_completion_bash }}"
+
+- name: Copy the bashrc.local configuration into place.
+  template:
+    src: templates/bash/bashrc.local.j2
+    dest: ~/.bashrc.local
+
+- name: Ensure the `~/.bashrc` file exists.
+  file:
+    path: ~/.bashrc
+    state: file
+
+- name: Ensure `~/.bashrc` loads ~/.bashrc.local if on Linux.
+  lineinfile:
+    path: ~/.bashrc
+    line: "[ -s ~/.bashrc.local ] && source ~/.bashrc.local"
+
+- name: Ensure the `~/.utility_*` directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ utility_script_dir }}"
+    - "{{ utility_bin_dir }}"
+
+- name: Copy the directory of utility scripts.
+  copy:
+    src: files/bash/utility_script
+    dest: "{{ utility_script_dir }}"
+
+- name: Copy the directory of utility binaries.
+  copy:
+    src: files/bash/utility_bin
+    dest: "{{ utility_bin_dir }}"
+
+- name: Copy the bash.aliases configuration into place.
+  copy:
+    src: files/bash/bash_aliases
+    dest: ~/.bash_aliases
+
 - name: Copy tmux configuration into place.
   copy:
     src: files/tmux/tmux.conf

--- a/templates/bash/bashrc.local.j2
+++ b/templates/bash/bashrc.local.j2
@@ -1,0 +1,14 @@
+# ~/.bashrc.local Additional configurations to bashrc.
+
+# Source the default python virtual environment.
+source {{ virtual_env }}/bin/activate
+
+# Enable git autocompletion.
+source {{ git_completion_bash }}
+
+# Set vi for editor shortcuts and vim as the default editor.
+set -o vi
+export EDITOR='vim'
+
+# Update $PATH to include the `~/.utility_[script|bin]_dir`
+PATH=$PATH:{{ utility_script_dir }}:{{ utility_bin_dir }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,3 +20,7 @@ pip_packages:
   - Sphinx
 
 virtual_env: "~/.venv"
+git_completion_bash: "~/.git-completion.bash"
+
+utility_script_dir: "~/.utility_script"
+utility_bin_dir: "~/.utility_bin"


### PR DESCRIPTION
Add support for ~/.bashrc, .bash_aliases,
and `~/utility_{script,bin}` directories which
contain useful scripts and bins I want available
in my path across all machines.