### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+roles

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 retry_files_enabled = False
+roles_path          = ./roles

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,9 @@ then
         sudo apt-add-repository ppa:ansible/ansible
         sudo apt-get update
         sudo apt-get install ansible
+
+        mkdir roles
+        ansible-galaxy install -r requirements.yml
     else
         exit 1
     fi

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,6 +15,7 @@
     - name: Install and uninstall OS-specific packages.
       include: "tasks/packages-{{ ansible_os_family }}.yml"
       static: no
+      become: yes
 
     - name: Configure users.
       include: "tasks/users.yml"
@@ -31,3 +32,8 @@
 
     - name: Install python and relevant packages.
       include: "tasks/python.yml"
+
+    - name: Install Docker (separately if on Linux machine).
+      include: "tasks/docker.yml"
+      when: ansible_os_family == "Debian"
+      become: yes

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+---
+- src: geerlingguy.docker

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,0 +1,4 @@
+---
+- name: Include the Docker role to handle installation.
+  include_role:
+    name: geerlingguy.docker

--- a/tasks/packages-Debian.yml
+++ b/tasks/packages-Debian.yml
@@ -3,42 +3,35 @@
   apt_key:
     keyserver: "{{ item.keyserver }}"
     id: "{{ item.id }}"
-  become: yes
   with_items: "{{ keyservers_to_add }}"
 
 - name: Add the necessary additional apt repositories.
   apt_repository:
     repo: "{{ item }}"
     state: present
-  become: yes
   with_items: "{{ apt_repositories_to_add }}"
 
 - name: Install the desired packages.
   apt:
     name: "{{ item }}"
     state: latest
-  become: yes
   with_items: "{{ packages_to_install }}"
 
 - name: Install the desired debs.
   apt:
     deb: "{{ item }}"
-  become: yes
   with_items: "{{ debs_to_install }}"
 
 - name: Uninstall the desired packages.
   apt:
     name: "{{ item }}"
     state: absent
-  become: yes
   with_items: "{{ packages_to_uninstall }}"
 
 - name: Remove useless packages from the cache.
   apt:
     autoclean: yes
-  become: yes
 
 - name: Remove dependencies that are no longer required.
   apt:
     autoremove: yes
-  become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,6 +14,7 @@ ssh_key_suffixes:
 
 pip_packages:
   - boto
+  - docker-py
   - dopy
   - pylint
   - jupyter


### PR DESCRIPTION
Fix #8 

Add support for installing docker and docker-compose.yml
through apt (so will work for Debian and Ubuntu). On OsX, we
can just use homebrew, so this will be less of a big deal.