### PR TITLE
Configure xinput mouse on i3 start

### DIFF
--- a/files/bash/utility_script/xinput_configuration.sh
+++ b/files/bash/utility_script/xinput_configuration.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+# Configure any connected mouse devices with decreased acceleration
+# and natural scrolling.
+#
+# Most effectively run on system login (i.e. called from `~/.profile`.
+#
+# Usage:
+#     xinput_configuration.sh
+
+# Currently this only works with my `Anker` mouse. Update to use a more
+# generic mapping between settings amd values for different types of mouses.
+configure_input() {
+    while [ $# -gt 0 ]
+    do
+        accel_setting="Device Accel Constant Deceleration"
+        accel_value="2.0"
+        if xinput --list-props "$1" | grep -q "$accel_setting"
+        then
+            xinput --set-prop "$1" "$accel_setting" $accel_value
+        fi
+
+        scrolling_setting="Evdev Scrolling Distance"
+        scrolling_value="-1, -1, -1"
+        if xinput --list-props "$1" | grep -q "$scrolling_setting"
+        then
+            xinput --set-prop "$1" "$scrolling_setting" $scrolling_value
+        fi
+
+        shift
+    done
+}
+
+export -f configure_input
+
+xinput --list |
+    grep -E ".*slave.*pointer.*" |
+        tr -cd '[:alnum:][:punct:][:space:]' |
+            sed -e 's/\s\+/ /g' -e 's/^\s//g' |
+                grep -Eo ".*id=" |
+                    sed -e 's/\s\+id=//g' |
+                        xargs -d '\n' bash -c 'configure_input "$@"' "$0"

--- a/files/vim/vimrc.local
+++ b/files/vim/vimrc.local
@@ -58,3 +58,4 @@ autocmd Filetype php setlocal ts=4 sts=4 sw=4
 autocmd Filetype go setlocal ts=8 sts=8 sw=8 nolist
 autocmd Filetype python setlocal ts=4 sts=4 sw=4
 autocmd Filetype java setlocal ts=4 sts=4 sw=4
+autocmd Filetype sh setlocal ts=4 sts=4 sw=4

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -9,33 +9,62 @@
     src: templates/bash/bashrc.local.j2
     dest: ~/.bashrc.local
 
+- name: Copy the `profile.local` file into place.
+  template:
+    src: templates/bash/profile.local.j2
+    dest: ~/.profile.local
+
 - name: Ensure the `~/.bashrc` file exists.
   file:
     path: ~/.bashrc
     state: file
 
-- name: Ensure `~/.bashrc` loads ~/.bashrc.local if on Linux.
+- name: Ensure `~/.bashrc` loads `~/.bashrc.local`
   lineinfile:
     path: ~/.bashrc
     line: "[ -s ~/.bashrc.local ] && source ~/.bashrc.local"
 
-- name: Ensure the `~/.utility_*` directories exist
+- name: Ensure the `~/.profile` file exists.
   file:
-    path: "{{ item }}"
+    path: ~/.profile
+    state: file
+
+- name: Ensure `~/.profile` loads ~/.profile.local`.
+  lineinfile:
+    path: ~/.profile
+    line: "[ -s ~/.profile.local ] && source ~/.profile.local"
+
+- name: Create the utility dirs
+  file:
     state: directory
+    path: "{{ item }}"
   with_items:
     - "{{ utility_script_dir }}"
     - "{{ utility_bin_dir }}"
 
 - name: Copy the directory of utility scripts.
   copy:
-    src: files/bash/utility_script
-    dest: "{{ utility_script_dir }}"
+    src: "{{ item }}"
+    dest: "{{ utility_script_dir }}/"
+  with_fileglob:
+    - files/bash/utility_script/*
 
 - name: Copy the directory of utility binaries.
   copy:
-    src: files/bash/utility_bin
-    dest: "{{ utility_bin_dir }}"
+    src: "{{ item }}"
+    dest: "{{ utility_bin_dir }}/"
+  with_fileglob:
+    - files/bash/utility_bin/*
+
+- name: Set the utility directories to be executable only by the user.
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0700
+    recurse: yes
+  with_items:
+    - "{{ utility_script_dir }}"
+    - "{{ utility_bin_dir }}"
 
 - name: Copy the bash.aliases configuration into place.
   copy:

--- a/tasks/i3.yml
+++ b/tasks/i3.yml
@@ -5,8 +5,8 @@
     state: directory
 
 - name: Copy the i3 configuration file.
-  copy:
-    src: files/i3/config
+  template:
+    src: templates/i3/config.j2
     dest: ~/.config/i3/config
 
 - name: Check if using lxdm

--- a/templates/bash/profile.local.j2
+++ b/templates/bash/profile.local.j2
@@ -1,0 +1,3 @@
+# ~/.profile.local Additional configuration to run on login.
+
+# @TODO(mattjmcnaughton) is this necessary in addition to `~/.bashrc`?

--- a/templates/i3/config.j2
+++ b/templates/i3/config.j2
@@ -9,6 +9,9 @@
 #
 # Please see http://i3wm.org/docs/userguide.html for a complete reference!
 
+# Startup
+exec_always --no-startup-id {{ utility_script_dir }}/xinput_configuration.sh
+
 set $mod Mod1
 
 # Font for window titles. Will also be used by the bar unless a different font


### PR DESCRIPTION
Fix #21 

Add a utility script for configuring my mouse to
use reverse scrolling and be less sensitive. Set up
i3 to run this script on boot.

Using i3 appears to be the best method for running this script.
I also tried `~/.profile`, a `reboot` cron, and `~/.xinitrc`,
and none of them appeared to actually call the script when
I wanted.

I left the option of specifying a `~/.profile.local` in case
I decide that could be useful in the future.