### PR TITLE
Install `brockman` to monitor background jobs

### DIFF
--- a/files/bash/utility_script/xinput_configuration.sh
+++ b/files/bash/utility_script/xinput_configuration.sh
@@ -2,8 +2,6 @@
 # Configure any connected mouse devices with decreased acceleration
 # and natural scrolling.
 #
-# Most effectively run on system login (i.e. called from `~/.profile`.
-#
 # Usage:
 #     xinput_configuration.sh
 

--- a/files/vim/vimrc.local
+++ b/files/vim/vimrc.local
@@ -59,3 +59,7 @@ autocmd Filetype go setlocal ts=8 sts=8 sw=8 nolist
 autocmd Filetype python setlocal ts=4 sts=4 sw=4
 autocmd Filetype java setlocal ts=4 sts=4 sw=4
 autocmd Filetype sh setlocal ts=4 sts=4 sw=4
+
+" Properly configure file types when extensions (such as `.j2` or `.erb`)
+" confuse Vim.
+autocmd Bufread,BufNewFile *.sh.* setfiletype sh

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -49,6 +49,13 @@
   with_fileglob:
     - files/bash/utility_script/*
 
+- name: Copy in the external utility scripts.
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ utility_script_dir }}/{{ item.file_name }}"
+  with_items:
+    - { url: "https://raw.githubusercontent.com/mattjmcnaughton/brockman/master/brockman.sh", file_name: "brockman.sh" }
+
 - name: Copy the directory of utility binaries.
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
Fix #20 

Include the separate utility script called `brockman`
to track my background jobs. It is housed in a different project
to make it easier to iterate on and give better directory
structure.