### PR TITLE
Add hugo to installed packages

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,6 +11,7 @@ packages_to_install:
   - clamav
   - git
   - golang-go
+  - hugo
   - i3
   - irssi
   - mutt


### PR DESCRIPTION
Add `hugo`, the static site generator I use for my blog,
to the default packages to install.